### PR TITLE
Fixed coin spawning, code cleanup

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -20042,6 +20042,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: START_AREA
       objectReference: {fileID: 0}
+    - target: {fileID: 3970917946389527716, guid: 2107a91c5eceba74d85fd21cda86dced, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects:

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -10,7 +10,7 @@ public class GameManager : MonoBehaviour
     public TMPro.TextMeshProUGUI scoreText;
     public TMPro.TextMeshProUGUI highScoreText;
     public int score = 0;
-    public int highScore;
+    private int highScore;
     private SoundManager soundManager;
     private void Awake()
     {

--- a/Assets/Scripts/LanePool.cs
+++ b/Assets/Scripts/LanePool.cs
@@ -11,9 +11,7 @@ public class LanePool : MonoBehaviour
     public float safeZone = 15.0f;
     private int maximumLanes = 3;
     private List<GameObject> activeLanes;
-
-    private int maxCoinsPerLane = 20;
-    private float zRange = 20.0f;
+    private int maxCoinsPerLane = 70;
 
 
     public GameObject coinPrefab;
@@ -26,7 +24,6 @@ public class LanePool : MonoBehaviour
         for (int i = 0; i < maximumLanes; i++)
         {
             SpawnLane(0);
-
         }
     }
 
@@ -35,9 +32,11 @@ public class LanePool : MonoBehaviour
     {
         if (playerTransform.position.z - safeZone > (spawnZ - maximumLanes * length))
         {
+            DeleteAllCoins();
+            DeleteLane();
+
             SpawnLane(0);
             SpawnCoins();
-            DeleteLane();
         }
     }
     private void SpawnLane(int prefab = -1)
@@ -52,15 +51,20 @@ public class LanePool : MonoBehaviour
 
     private void SpawnCoins()
     {
-        for (int i = 0; i < maxCoinsPerLane; i++)
+        GameObject player = GameObject.Find("Player");
+
+        if (player != null)
         {
-            float randomX = Random.Range(0.0f, 20.0f); // Random X position in the lane
-            float randomY = 1.0f; // Adjust this based on your desired Y position
-            float randomZ = Random.Range(-zRange, zRange); // Random Z position within a specified range
+            for (int i = 0; i < maxCoinsPerLane; i++)
+            {
+                float randomX = Random.Range((int)-safeZone, (int)safeZone + 1); // Random X position in the lane
+                float randomY = 1.0f;
+                float randomZ = Random.Range(player.transform.position.z - length, player.transform.position.z + length); // this should follow the lane as it moves
 
-            Vector3 spawnPosition = new Vector3(randomX, randomY, randomZ);
+                Vector3 spawnPosition = new Vector3(randomX, randomY, randomZ);
 
-            Instantiate(coinPrefab, spawnPosition, Quaternion.identity);
+                Instantiate(coinPrefab, spawnPosition, Quaternion.identity);
+            }
         }
     }
 
@@ -68,5 +72,15 @@ public class LanePool : MonoBehaviour
     {
         Destroy(activeLanes[0]);
         activeLanes.RemoveAt(0);
+    }
+
+    private void DeleteAllCoins()
+    {
+        CoinHandler[] coinHandlers = GameObject.FindObjectsOfType<CoinHandler>();
+
+        foreach (CoinHandler coinHandler in coinHandlers)
+        {
+            Destroy(coinHandler.gameObject);
+        }
     }
 }


### PR DESCRIPTION
Fixed the issue where the coins only spawn once in the game. When the player progresses and a new lane is instantiated, old coin game objects are destroyed and new ones are spawned around the player's current position.